### PR TITLE
Doc: fix image paths on GitHub

### DIFF
--- a/nanosvg/README.md
+++ b/nanosvg/README.md
@@ -5,7 +5,7 @@ Nano SVG
 
 ## Parser
 
-![screenshot of some splines rendered with the sample program](/example/screenshot-1.png?raw=true)
+![screenshot of some splines rendered with the sample program](example/screenshot-1.png?raw=true)
 
 NanoSVG is a simple stupid single-header-file SVG parse. The output of the parser is a list of cubic bezier shapes.
 
@@ -26,7 +26,7 @@ If you don't know or care about the units stuff, "px" and 96 should get you goin
 
 ## Rasterizer
 
-![screenshot of tiger.svg rendered with NanoSVG rasterizer](/example/screenshot-2.png?raw=true)
+![screenshot of tiger.svg rendered with NanoSVG rasterizer](example/screenshot-2.png?raw=true)
 
 The parser library is accompanied with really simpler SVG rasterizer. Currently it only renders flat filled shapes.
 


### PR DESCRIPTION
When porting this over from BitBucket, I guess that the image path differs — on BitBucket, they seem to be absolute, while GitHub prefers them relative.

I just wanted to see those images shown on the README :-) I'm well aware that this is 'abandonware', which is a pity, really. I'm sure there are a _lot_ of interesting applications for this kind of library inside the SL Viewer...;-)